### PR TITLE
Implement activity and level data sources with repository pattern

### DIFF
--- a/lib/core/di/di_repository_module.dart
+++ b/lib/core/di/di_repository_module.dart
@@ -1,9 +1,15 @@
+import 'package:imitador/core/repository/activity_repository.dart';
+import 'package:imitador/core/repository/level_repository.dart';
 import 'package:imitador/core/repository/session_repository.dart';
+import 'package:imitador/core/source/activity/activity_local_source.dart';
+import 'package:imitador/core/source/activity/activity_remote_source.dart';
 import 'package:imitador/core/source/auth_local_source.dart';
 import 'package:imitador/core/source/auth_remote_source.dart';
 import 'package:imitador/core/source/common/auth_interceptor.dart';
 import 'package:imitador/core/source/common/http_service.dart';
 import 'package:get_it/get_it.dart';
+import 'package:imitador/core/source/level/level_local_source.dart';
+import 'package:imitador/core/source/level/level_remote_source.dart';
 
 class RepositoryDiModule {
   RepositoryDiModule._privateConstructor();
@@ -28,10 +34,16 @@ extension _GetItDiModuleExtensions on GetIt {
 
   void _setupRepositories() {
     registerLazySingleton(() => SessionRepository(get(), get()));
+    registerLazySingleton(() => LevelRepository(get(), get()));
+    registerLazySingleton(() => ActivityRepository(get(), get()));
   }
 
   void _setupSources() {
     registerLazySingleton(() => AuthLocalSource(get()));
     registerLazySingleton(() => AuthRemoteSource(get()));
+    registerLazySingleton(() => LevelRemoteSource(get()));
+    registerLazySingleton(() => LevelLocalSource());
+    registerLazySingleton(() => ActivityRemoteSource(get()));
+    registerLazySingleton(() => ActivityLocalSource());
   }
 }

--- a/lib/core/repository/activity_repository.dart
+++ b/lib/core/repository/activity_repository.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+
+import 'package:imitador/core/source/activity/activity_local_source.dart';
+import 'package:imitador/core/source/activity/activity_remote_source.dart';
+import 'package:imitador/core/source/level/level_local_source.dart';
+import 'package:imitador/core/source/level/level_remote_source.dart';
+import 'package:imitador/model/activity/activity.dart';
+import 'package:imitador/model/level/level.dart';
+import 'package:stock/stock.dart';
+
+class ActivityRepository {
+  final ActivityLocalSource _levelLocalSource;
+  final ActivityRemoteSource _levelRemoteSource;
+
+  final Stock<dynamic, List<Activity>> _store;
+
+  ActivityRepository(
+    this._levelLocalSource,
+    this._levelRemoteSource,
+  ) : _store = Stock(
+          fetcher: Fetcher.ofFuture(
+            (_) => _levelRemoteSource.getActivities(),
+          ),
+          sourceOfTruth: SourceOfTruth<dynamic, List<Activity>>(
+            reader: (_) => _levelLocalSource.getElementsStream(),
+            writer: (_, value) =>
+                _levelLocalSource.replaceActivities(value ?? []),
+          ),
+        );
+
+  Stream<List<Activity>?> getActivities() => _store
+      .stream(null)
+      .where((event) => event.isData)
+      .map((event) => event.requireData());
+}

--- a/lib/core/repository/level_repository.dart
+++ b/lib/core/repository/level_repository.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+
+import 'package:imitador/core/source/level/level_local_source.dart';
+import 'package:imitador/core/source/level/level_remote_source.dart';
+import 'package:imitador/model/level/level.dart';
+import 'package:stock/stock.dart';
+
+class LevelRepository {
+  final LevelLocalSource _levelLocalSource;
+  final LevelRemoteSource _levelRemoteSource;
+
+  final Stock<dynamic, List<Level>> _store;
+
+  LevelRepository(
+    this._levelLocalSource,
+    this._levelRemoteSource,
+  ) : _store = Stock(
+          fetcher: Fetcher.ofFuture(
+            (_) => _levelRemoteSource.getLevels(),
+          ),
+          sourceOfTruth: SourceOfTruth<dynamic, List<Level>>(
+            reader: (_) => _levelLocalSource.getElementsStream(),
+            writer: (_, value) =>
+                _levelLocalSource.replaceLevels(value ?? []),
+          ),
+        );
+
+  Future<List<Level>?> getDirectLevels() => _levelRemoteSource.getLevels();
+
+  Stream<List<Level>?> getLevels() => _store
+      .stream(null)
+      .where((event) => event.isData)
+      .map((event) => event.requireData());
+}

--- a/lib/core/source/activity/activity_local_source.dart
+++ b/lib/core/source/activity/activity_local_source.dart
@@ -1,0 +1,22 @@
+import 'package:imitador/core/source/common/hive_base_source.dart';
+import 'package:imitador/model/activity/activity.dart';
+
+
+class ActivityLocalSource extends HiveBaseSource<String, Activity> {
+  ActivityLocalSource()
+      : super(
+    dbParser: (activity) => activity.toJson(),
+    modelParser: (activity) => Activity.fromJson(activity),
+  );
+
+  Future<List<Activity>> replaceActivities(List<Activity> elements) async {
+    await deleteAllElements();
+    return putAllElements(
+      Map.fromEntries(
+        elements.map(
+              (e) => MapEntry(e.id, e),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/source/activity/activity_remote_source.dart
+++ b/lib/core/source/activity/activity_remote_source.dart
@@ -1,0 +1,20 @@
+import 'package:imitador/core/common/model/service/service_response.dart';
+import 'package:imitador/core/source/common/http_service.dart';
+import 'package:imitador/model/activity/activity.dart';
+
+class ActivityRemoteSource {
+  static const _urlGetActivities = '/v1/activities';
+
+  final HttpServiceDio _httpService;
+
+  ActivityRemoteSource(this._httpService);
+
+  Future<List<Activity>> getActivities() => _httpService
+      .getAndProcessResponse(
+        _urlGetActivities,
+        serializer: (listResponse) => (listResponse as List)
+            .map((activity) => Activity.fromJson(activity))
+            .toList(),
+      )
+      .then((value) => value.getDataOrThrow());
+}

--- a/lib/core/source/level/level_local_source.dart
+++ b/lib/core/source/level/level_local_source.dart
@@ -1,0 +1,22 @@
+import 'package:imitador/core/source/common/hive_base_source.dart';
+import 'package:imitador/model/level/level.dart';
+
+
+class LevelLocalSource extends HiveBaseSource<String, Level> {
+  LevelLocalSource()
+      : super(
+    dbParser: (level) => level.toJson(),
+    modelParser: (level) => Level.fromJson(level),
+  );
+
+  Future<List<Level>> replaceLevels(List<Level> elements) async {
+    await deleteAllElements();
+    return putAllElements(
+      Map.fromEntries(
+        elements.map(
+              (e) => MapEntry(e.id, e),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/source/level/level_remote_source.dart
+++ b/lib/core/source/level/level_remote_source.dart
@@ -1,0 +1,23 @@
+import 'package:imitador/core/common/model/service/service_response.dart';
+import 'package:imitador/core/source/common/http_service.dart';
+import 'package:imitador/model/level/level.dart';
+
+class LevelRemoteSource {
+  static const _urlGetLevels = '/v1/levels';
+
+  final HttpServiceDio _httpService;
+
+  LevelRemoteSource(this._httpService);
+
+  Future<List<Level>> getLevels() => _httpService
+      .getAndProcessResponse(
+        _urlGetLevels,
+        serializer: (listResponse) => (listResponse as List).map((level) {
+          level['duration'] = level['duration'] is String
+              ? double.parse(level['duration'])
+              : level['duration'];
+          return Level.fromJson(level);
+        }).toList(),
+      )
+      .then((value) => value.getDataOrThrow());
+}

--- a/lib/model/enum/difficulty.dart
+++ b/lib/model/enum/difficulty.dart
@@ -1,5 +1,7 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
 enum Difficulty {
-  easy,
-  medium,
-  hard
+  @JsonValue("EASY") easy,
+  @JsonValue("MEDIUM") medium,
+  @JsonValue("HARD") hard,
 }

--- a/lib/model/level/level.dart
+++ b/lib/model/level/level.dart
@@ -11,27 +11,16 @@ part 'level.g.dart';
 
 @freezed
 sealed class Level with _$Level {
-  factory Level.fixed({
+  factory Level({
     required String id,
     required String name,
-    @PairConverter() required Pair<double, double> range,
-    required double secondsDuration,
+    required Difficulty? difficulty,
+    required double minPosition,
+    required double maxPosition,
+    @JsonKey(name: "duration") required double secondsDuration,
     @Default(LevelType.position) LevelType type,
     @ExpressionConverter() required LevelExpressions expressions,
-  }) = FixedLevel;
-
-  factory Level.random({
-    required String id,
-    required String name,
-    required Difficulty difficulty,
-    @Default(LevelType.position) LevelType type,
-    @PairConverter() required Pair<double, double> range,
-    required double secondsDuration,
-    @ExpressionConverter()
-    @Default([])
-    LevelExpressions
-        expressions, // Maybe we need this to keep historic records
-  }) = RandomLevel;
+  }) = _Level;
 
   factory Level.fromJson(Map<String, dynamic> json) => _$LevelFromJson(json);
 }

--- a/lib/model/level/level.freezed.dart
+++ b/lib/model/level/level.freezed.dart
@@ -15,111 +15,22 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
 Level _$LevelFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
-    case 'fixed':
-      return FixedLevel.fromJson(json);
-    case 'random':
-      return RandomLevel.fromJson(json);
-
-    default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'Level',
-          'Invalid union type "${json['runtimeType']}"!');
-  }
+  return _Level.fromJson(json);
 }
 
 /// @nodoc
 mixin _$Level {
   String get id => throw _privateConstructorUsedError;
   String get name => throw _privateConstructorUsedError;
-  @PairConverter()
-  Pair<double, double> get range => throw _privateConstructorUsedError;
+  Difficulty? get difficulty => throw _privateConstructorUsedError;
+  double get minPosition => throw _privateConstructorUsedError;
+  double get maxPosition => throw _privateConstructorUsedError;
+  @JsonKey(name: "duration")
   double get secondsDuration => throw _privateConstructorUsedError;
   LevelType get type => throw _privateConstructorUsedError;
   @ExpressionConverter()
   List<Expression> get expressions => throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(
-            String id,
-            String name,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            LevelType type,
-            @ExpressionConverter() List<Expression> expressions)
-        fixed,
-    required TResult Function(
-            String id,
-            String name,
-            Difficulty difficulty,
-            LevelType type,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            @ExpressionConverter() List<Expression> expressions)
-        random,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            String id,
-            String name,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            LevelType type,
-            @ExpressionConverter() List<Expression> expressions)?
-        fixed,
-    TResult? Function(
-            String id,
-            String name,
-            Difficulty difficulty,
-            LevelType type,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            @ExpressionConverter() List<Expression> expressions)?
-        random,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            String id,
-            String name,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            LevelType type,
-            @ExpressionConverter() List<Expression> expressions)?
-        fixed,
-    TResult Function(
-            String id,
-            String name,
-            Difficulty difficulty,
-            LevelType type,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            @ExpressionConverter() List<Expression> expressions)?
-        random,
-    required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(FixedLevel value) fixed,
-    required TResult Function(RandomLevel value) random,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(FixedLevel value)? fixed,
-    TResult? Function(RandomLevel value)? random,
-  }) =>
-      throw _privateConstructorUsedError;
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(FixedLevel value)? fixed,
-    TResult Function(RandomLevel value)? random,
-    required TResult orElse(),
-  }) =>
-      throw _privateConstructorUsedError;
+
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
   $LevelCopyWith<Level> get copyWith => throw _privateConstructorUsedError;
@@ -133,8 +44,10 @@ abstract class $LevelCopyWith<$Res> {
   $Res call(
       {String id,
       String name,
-      @PairConverter() Pair<double, double> range,
-      double secondsDuration,
+      Difficulty? difficulty,
+      double minPosition,
+      double maxPosition,
+      @JsonKey(name: "duration") double secondsDuration,
       LevelType type,
       @ExpressionConverter() List<Expression> expressions});
 }
@@ -154,7 +67,9 @@ class _$LevelCopyWithImpl<$Res, $Val extends Level>
   $Res call({
     Object? id = null,
     Object? name = null,
-    Object? range = null,
+    Object? difficulty = freezed,
+    Object? minPosition = null,
+    Object? maxPosition = null,
     Object? secondsDuration = null,
     Object? type = null,
     Object? expressions = null,
@@ -168,10 +83,18 @@ class _$LevelCopyWithImpl<$Res, $Val extends Level>
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      range: null == range
-          ? _value.range
-          : range // ignore: cast_nullable_to_non_nullable
-              as Pair<double, double>,
+      difficulty: freezed == difficulty
+          ? _value.difficulty
+          : difficulty // ignore: cast_nullable_to_non_nullable
+              as Difficulty?,
+      minPosition: null == minPosition
+          ? _value.minPosition
+          : minPosition // ignore: cast_nullable_to_non_nullable
+              as double,
+      maxPosition: null == maxPosition
+          ? _value.maxPosition
+          : maxPosition // ignore: cast_nullable_to_non_nullable
+              as double,
       secondsDuration: null == secondsDuration
           ? _value.secondsDuration
           : secondsDuration // ignore: cast_nullable_to_non_nullable
@@ -189,27 +112,29 @@ class _$LevelCopyWithImpl<$Res, $Val extends Level>
 }
 
 /// @nodoc
-abstract class _$$FixedLevelImplCopyWith<$Res> implements $LevelCopyWith<$Res> {
-  factory _$$FixedLevelImplCopyWith(
-          _$FixedLevelImpl value, $Res Function(_$FixedLevelImpl) then) =
-      __$$FixedLevelImplCopyWithImpl<$Res>;
+abstract class _$$LevelImplCopyWith<$Res> implements $LevelCopyWith<$Res> {
+  factory _$$LevelImplCopyWith(
+          _$LevelImpl value, $Res Function(_$LevelImpl) then) =
+      __$$LevelImplCopyWithImpl<$Res>;
   @override
   @useResult
   $Res call(
       {String id,
       String name,
-      @PairConverter() Pair<double, double> range,
-      double secondsDuration,
+      Difficulty? difficulty,
+      double minPosition,
+      double maxPosition,
+      @JsonKey(name: "duration") double secondsDuration,
       LevelType type,
       @ExpressionConverter() List<Expression> expressions});
 }
 
 /// @nodoc
-class __$$FixedLevelImplCopyWithImpl<$Res>
-    extends _$LevelCopyWithImpl<$Res, _$FixedLevelImpl>
-    implements _$$FixedLevelImplCopyWith<$Res> {
-  __$$FixedLevelImplCopyWithImpl(
-      _$FixedLevelImpl _value, $Res Function(_$FixedLevelImpl) _then)
+class __$$LevelImplCopyWithImpl<$Res>
+    extends _$LevelCopyWithImpl<$Res, _$LevelImpl>
+    implements _$$LevelImplCopyWith<$Res> {
+  __$$LevelImplCopyWithImpl(
+      _$LevelImpl _value, $Res Function(_$LevelImpl) _then)
       : super(_value, _then);
 
   @pragma('vm:prefer-inline')
@@ -217,12 +142,14 @@ class __$$FixedLevelImplCopyWithImpl<$Res>
   $Res call({
     Object? id = null,
     Object? name = null,
-    Object? range = null,
+    Object? difficulty = freezed,
+    Object? minPosition = null,
+    Object? maxPosition = null,
     Object? secondsDuration = null,
     Object? type = null,
     Object? expressions = null,
   }) {
-    return _then(_$FixedLevelImpl(
+    return _then(_$LevelImpl(
       id: null == id
           ? _value.id
           : id // ignore: cast_nullable_to_non_nullable
@@ -231,308 +158,26 @@ class __$$FixedLevelImplCopyWithImpl<$Res>
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      range: null == range
-          ? _value.range
-          : range // ignore: cast_nullable_to_non_nullable
-              as Pair<double, double>,
-      secondsDuration: null == secondsDuration
-          ? _value.secondsDuration
-          : secondsDuration // ignore: cast_nullable_to_non_nullable
-              as double,
-      type: null == type
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as LevelType,
-      expressions: null == expressions
-          ? _value._expressions
-          : expressions // ignore: cast_nullable_to_non_nullable
-              as List<Expression>,
-    ));
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$FixedLevelImpl implements FixedLevel {
-  _$FixedLevelImpl(
-      {required this.id,
-      required this.name,
-      @PairConverter() required this.range,
-      required this.secondsDuration,
-      this.type = LevelType.position,
-      @ExpressionConverter() required final List<Expression> expressions,
-      final String? $type})
-      : _expressions = expressions,
-        $type = $type ?? 'fixed';
-
-  factory _$FixedLevelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$FixedLevelImplFromJson(json);
-
-  @override
-  final String id;
-  @override
-  final String name;
-  @override
-  @PairConverter()
-  final Pair<double, double> range;
-  @override
-  final double secondsDuration;
-  @override
-  @JsonKey()
-  final LevelType type;
-  final List<Expression> _expressions;
-  @override
-  @ExpressionConverter()
-  List<Expression> get expressions {
-    if (_expressions is EqualUnmodifiableListView) return _expressions;
-    // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_expressions);
-  }
-
-  @JsonKey(name: 'runtimeType')
-  final String $type;
-
-  @override
-  String toString() {
-    return 'Level.fixed(id: $id, name: $name, range: $range, secondsDuration: $secondsDuration, type: $type, expressions: $expressions)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$FixedLevelImpl &&
-            (identical(other.id, id) || other.id == id) &&
-            (identical(other.name, name) || other.name == name) &&
-            (identical(other.range, range) || other.range == range) &&
-            (identical(other.secondsDuration, secondsDuration) ||
-                other.secondsDuration == secondsDuration) &&
-            (identical(other.type, type) || other.type == type) &&
-            const DeepCollectionEquality()
-                .equals(other._expressions, _expressions));
-  }
-
-  @JsonKey(ignore: true)
-  @override
-  int get hashCode => Object.hash(runtimeType, id, name, range, secondsDuration,
-      type, const DeepCollectionEquality().hash(_expressions));
-
-  @JsonKey(ignore: true)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$FixedLevelImplCopyWith<_$FixedLevelImpl> get copyWith =>
-      __$$FixedLevelImplCopyWithImpl<_$FixedLevelImpl>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(
-            String id,
-            String name,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            LevelType type,
-            @ExpressionConverter() List<Expression> expressions)
-        fixed,
-    required TResult Function(
-            String id,
-            String name,
-            Difficulty difficulty,
-            LevelType type,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            @ExpressionConverter() List<Expression> expressions)
-        random,
-  }) {
-    return fixed(id, name, range, secondsDuration, type, expressions);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            String id,
-            String name,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            LevelType type,
-            @ExpressionConverter() List<Expression> expressions)?
-        fixed,
-    TResult? Function(
-            String id,
-            String name,
-            Difficulty difficulty,
-            LevelType type,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            @ExpressionConverter() List<Expression> expressions)?
-        random,
-  }) {
-    return fixed?.call(id, name, range, secondsDuration, type, expressions);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            String id,
-            String name,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            LevelType type,
-            @ExpressionConverter() List<Expression> expressions)?
-        fixed,
-    TResult Function(
-            String id,
-            String name,
-            Difficulty difficulty,
-            LevelType type,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            @ExpressionConverter() List<Expression> expressions)?
-        random,
-    required TResult orElse(),
-  }) {
-    if (fixed != null) {
-      return fixed(id, name, range, secondsDuration, type, expressions);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(FixedLevel value) fixed,
-    required TResult Function(RandomLevel value) random,
-  }) {
-    return fixed(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(FixedLevel value)? fixed,
-    TResult? Function(RandomLevel value)? random,
-  }) {
-    return fixed?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(FixedLevel value)? fixed,
-    TResult Function(RandomLevel value)? random,
-    required TResult orElse(),
-  }) {
-    if (fixed != null) {
-      return fixed(this);
-    }
-    return orElse();
-  }
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$FixedLevelImplToJson(
-      this,
-    );
-  }
-}
-
-abstract class FixedLevel implements Level {
-  factory FixedLevel(
-          {required final String id,
-          required final String name,
-          @PairConverter() required final Pair<double, double> range,
-          required final double secondsDuration,
-          final LevelType type,
-          @ExpressionConverter() required final List<Expression> expressions}) =
-      _$FixedLevelImpl;
-
-  factory FixedLevel.fromJson(Map<String, dynamic> json) =
-      _$FixedLevelImpl.fromJson;
-
-  @override
-  String get id;
-  @override
-  String get name;
-  @override
-  @PairConverter()
-  Pair<double, double> get range;
-  @override
-  double get secondsDuration;
-  @override
-  LevelType get type;
-  @override
-  @ExpressionConverter()
-  List<Expression> get expressions;
-  @override
-  @JsonKey(ignore: true)
-  _$$FixedLevelImplCopyWith<_$FixedLevelImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class _$$RandomLevelImplCopyWith<$Res>
-    implements $LevelCopyWith<$Res> {
-  factory _$$RandomLevelImplCopyWith(
-          _$RandomLevelImpl value, $Res Function(_$RandomLevelImpl) then) =
-      __$$RandomLevelImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {String id,
-      String name,
-      Difficulty difficulty,
-      LevelType type,
-      @PairConverter() Pair<double, double> range,
-      double secondsDuration,
-      @ExpressionConverter() List<Expression> expressions});
-}
-
-/// @nodoc
-class __$$RandomLevelImplCopyWithImpl<$Res>
-    extends _$LevelCopyWithImpl<$Res, _$RandomLevelImpl>
-    implements _$$RandomLevelImplCopyWith<$Res> {
-  __$$RandomLevelImplCopyWithImpl(
-      _$RandomLevelImpl _value, $Res Function(_$RandomLevelImpl) _then)
-      : super(_value, _then);
-
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? id = null,
-    Object? name = null,
-    Object? difficulty = null,
-    Object? type = null,
-    Object? range = null,
-    Object? secondsDuration = null,
-    Object? expressions = null,
-  }) {
-    return _then(_$RandomLevelImpl(
-      id: null == id
-          ? _value.id
-          : id // ignore: cast_nullable_to_non_nullable
-              as String,
-      name: null == name
-          ? _value.name
-          : name // ignore: cast_nullable_to_non_nullable
-              as String,
-      difficulty: null == difficulty
+      difficulty: freezed == difficulty
           ? _value.difficulty
           : difficulty // ignore: cast_nullable_to_non_nullable
-              as Difficulty,
-      type: null == type
-          ? _value.type
-          : type // ignore: cast_nullable_to_non_nullable
-              as LevelType,
-      range: null == range
-          ? _value.range
-          : range // ignore: cast_nullable_to_non_nullable
-              as Pair<double, double>,
+              as Difficulty?,
+      minPosition: null == minPosition
+          ? _value.minPosition
+          : minPosition // ignore: cast_nullable_to_non_nullable
+              as double,
+      maxPosition: null == maxPosition
+          ? _value.maxPosition
+          : maxPosition // ignore: cast_nullable_to_non_nullable
+              as double,
       secondsDuration: null == secondsDuration
           ? _value.secondsDuration
           : secondsDuration // ignore: cast_nullable_to_non_nullable
               as double,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as LevelType,
       expressions: null == expressions
           ? _value._expressions
           : expressions // ignore: cast_nullable_to_non_nullable
@@ -543,39 +188,39 @@ class __$$RandomLevelImplCopyWithImpl<$Res>
 
 /// @nodoc
 @JsonSerializable()
-class _$RandomLevelImpl implements RandomLevel {
-  _$RandomLevelImpl(
+class _$LevelImpl implements _Level {
+  _$LevelImpl(
       {required this.id,
       required this.name,
       required this.difficulty,
+      required this.minPosition,
+      required this.maxPosition,
+      @JsonKey(name: "duration") required this.secondsDuration,
       this.type = LevelType.position,
-      @PairConverter() required this.range,
-      required this.secondsDuration,
-      @ExpressionConverter() final List<Expression> expressions = const [],
-      final String? $type})
-      : _expressions = expressions,
-        $type = $type ?? 'random';
+      @ExpressionConverter() required final List<Expression> expressions})
+      : _expressions = expressions;
 
-  factory _$RandomLevelImpl.fromJson(Map<String, dynamic> json) =>
-      _$$RandomLevelImplFromJson(json);
+  factory _$LevelImpl.fromJson(Map<String, dynamic> json) =>
+      _$$LevelImplFromJson(json);
 
   @override
   final String id;
   @override
   final String name;
   @override
-  final Difficulty difficulty;
+  final Difficulty? difficulty;
+  @override
+  final double minPosition;
+  @override
+  final double maxPosition;
+  @override
+  @JsonKey(name: "duration")
+  final double secondsDuration;
   @override
   @JsonKey()
   final LevelType type;
-  @override
-  @PairConverter()
-  final Pair<double, double> range;
-  @override
-  final double secondsDuration;
   final List<Expression> _expressions;
   @override
-  @JsonKey()
   @ExpressionConverter()
   List<Expression> get expressions {
     if (_expressions is EqualUnmodifiableListView) return _expressions;
@@ -583,27 +228,27 @@ class _$RandomLevelImpl implements RandomLevel {
     return EqualUnmodifiableListView(_expressions);
   }
 
-  @JsonKey(name: 'runtimeType')
-  final String $type;
-
   @override
   String toString() {
-    return 'Level.random(id: $id, name: $name, difficulty: $difficulty, type: $type, range: $range, secondsDuration: $secondsDuration, expressions: $expressions)';
+    return 'Level(id: $id, name: $name, difficulty: $difficulty, minPosition: $minPosition, maxPosition: $maxPosition, secondsDuration: $secondsDuration, type: $type, expressions: $expressions)';
   }
 
   @override
   bool operator ==(Object other) {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
-            other is _$RandomLevelImpl &&
+            other is _$LevelImpl &&
             (identical(other.id, id) || other.id == id) &&
             (identical(other.name, name) || other.name == name) &&
             (identical(other.difficulty, difficulty) ||
                 other.difficulty == difficulty) &&
-            (identical(other.type, type) || other.type == type) &&
-            (identical(other.range, range) || other.range == range) &&
+            (identical(other.minPosition, minPosition) ||
+                other.minPosition == minPosition) &&
+            (identical(other.maxPosition, maxPosition) ||
+                other.maxPosition == maxPosition) &&
             (identical(other.secondsDuration, secondsDuration) ||
                 other.secondsDuration == secondsDuration) &&
+            (identical(other.type, type) || other.type == type) &&
             const DeepCollectionEquality()
                 .equals(other._expressions, _expressions));
   }
@@ -615,166 +260,60 @@ class _$RandomLevelImpl implements RandomLevel {
       id,
       name,
       difficulty,
-      type,
-      range,
+      minPosition,
+      maxPosition,
       secondsDuration,
+      type,
       const DeepCollectionEquality().hash(_expressions));
 
   @JsonKey(ignore: true)
   @override
   @pragma('vm:prefer-inline')
-  _$$RandomLevelImplCopyWith<_$RandomLevelImpl> get copyWith =>
-      __$$RandomLevelImplCopyWithImpl<_$RandomLevelImpl>(this, _$identity);
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function(
-            String id,
-            String name,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            LevelType type,
-            @ExpressionConverter() List<Expression> expressions)
-        fixed,
-    required TResult Function(
-            String id,
-            String name,
-            Difficulty difficulty,
-            LevelType type,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            @ExpressionConverter() List<Expression> expressions)
-        random,
-  }) {
-    return random(
-        id, name, difficulty, type, range, secondsDuration, expressions);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(
-            String id,
-            String name,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            LevelType type,
-            @ExpressionConverter() List<Expression> expressions)?
-        fixed,
-    TResult? Function(
-            String id,
-            String name,
-            Difficulty difficulty,
-            LevelType type,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            @ExpressionConverter() List<Expression> expressions)?
-        random,
-  }) {
-    return random?.call(
-        id, name, difficulty, type, range, secondsDuration, expressions);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function(
-            String id,
-            String name,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            LevelType type,
-            @ExpressionConverter() List<Expression> expressions)?
-        fixed,
-    TResult Function(
-            String id,
-            String name,
-            Difficulty difficulty,
-            LevelType type,
-            @PairConverter() Pair<double, double> range,
-            double secondsDuration,
-            @ExpressionConverter() List<Expression> expressions)?
-        random,
-    required TResult orElse(),
-  }) {
-    if (random != null) {
-      return random(
-          id, name, difficulty, type, range, secondsDuration, expressions);
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(FixedLevel value) fixed,
-    required TResult Function(RandomLevel value) random,
-  }) {
-    return random(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(FixedLevel value)? fixed,
-    TResult? Function(RandomLevel value)? random,
-  }) {
-    return random?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(FixedLevel value)? fixed,
-    TResult Function(RandomLevel value)? random,
-    required TResult orElse(),
-  }) {
-    if (random != null) {
-      return random(this);
-    }
-    return orElse();
-  }
+  _$$LevelImplCopyWith<_$LevelImpl> get copyWith =>
+      __$$LevelImplCopyWithImpl<_$LevelImpl>(this, _$identity);
 
   @override
   Map<String, dynamic> toJson() {
-    return _$$RandomLevelImplToJson(
+    return _$$LevelImplToJson(
       this,
     );
   }
 }
 
-abstract class RandomLevel implements Level {
-  factory RandomLevel(
+abstract class _Level implements Level {
+  factory _Level(
           {required final String id,
           required final String name,
-          required final Difficulty difficulty,
+          required final Difficulty? difficulty,
+          required final double minPosition,
+          required final double maxPosition,
+          @JsonKey(name: "duration") required final double secondsDuration,
           final LevelType type,
-          @PairConverter() required final Pair<double, double> range,
-          required final double secondsDuration,
-          @ExpressionConverter() final List<Expression> expressions}) =
-      _$RandomLevelImpl;
+          @ExpressionConverter() required final List<Expression> expressions}) =
+      _$LevelImpl;
 
-  factory RandomLevel.fromJson(Map<String, dynamic> json) =
-      _$RandomLevelImpl.fromJson;
+  factory _Level.fromJson(Map<String, dynamic> json) = _$LevelImpl.fromJson;
 
   @override
   String get id;
   @override
   String get name;
-  Difficulty get difficulty;
+  @override
+  Difficulty? get difficulty;
+  @override
+  double get minPosition;
+  @override
+  double get maxPosition;
+  @override
+  @JsonKey(name: "duration")
+  double get secondsDuration;
   @override
   LevelType get type;
-  @override
-  @PairConverter()
-  Pair<double, double> get range;
-  @override
-  double get secondsDuration;
   @override
   @ExpressionConverter()
   List<Expression> get expressions;
   @override
   @JsonKey(ignore: true)
-  _$$RandomLevelImplCopyWith<_$RandomLevelImpl> get copyWith =>
+  _$$LevelImplCopyWith<_$LevelImpl> get copyWith =>
       throw _privateConstructorUsedError;
 }

--- a/lib/model/level/level.g.dart
+++ b/lib/model/level/level.g.dart
@@ -6,68 +6,40 @@ part of 'level.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-_$FixedLevelImpl _$$FixedLevelImplFromJson(Map<String, dynamic> json) =>
-    _$FixedLevelImpl(
+_$LevelImpl _$$LevelImplFromJson(Map<String, dynamic> json) => _$LevelImpl(
       id: json['id'] as String,
       name: json['name'] as String,
-      range: const PairConverter().fromJson(json['range'] as String),
-      secondsDuration: (json['secondsDuration'] as num).toDouble(),
+      difficulty: $enumDecodeNullable(_$DifficultyEnumMap, json['difficulty']),
+      minPosition: (json['minPosition'] as num).toDouble(),
+      maxPosition: (json['maxPosition'] as num).toDouble(),
+      secondsDuration: (json['duration'] as num).toDouble(),
       type: $enumDecodeNullable(_$LevelTypeEnumMap, json['type']) ??
           LevelType.position,
       expressions: (json['expressions'] as List<dynamic>)
           .map((e) => const ExpressionConverter().fromJson(e as String))
           .toList(),
-      $type: json['runtimeType'] as String?,
     );
 
-Map<String, dynamic> _$$FixedLevelImplToJson(_$FixedLevelImpl instance) =>
+Map<String, dynamic> _$$LevelImplToJson(_$LevelImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'name': instance.name,
-      'range': const PairConverter().toJson(instance.range),
-      'secondsDuration': instance.secondsDuration,
+      'difficulty': _$DifficultyEnumMap[instance.difficulty],
+      'minPosition': instance.minPosition,
+      'maxPosition': instance.maxPosition,
+      'duration': instance.secondsDuration,
       'type': _$LevelTypeEnumMap[instance.type]!,
       'expressions':
           instance.expressions.map(const ExpressionConverter().toJson).toList(),
-      'runtimeType': instance.$type,
     };
+
+const _$DifficultyEnumMap = {
+  Difficulty.easy: 'EASY',
+  Difficulty.medium: 'MEDIUM',
+  Difficulty.hard: 'HARD',
+};
 
 const _$LevelTypeEnumMap = {
   LevelType.position: 'POSITION',
   LevelType.speed: 'SPEED',
-};
-
-_$RandomLevelImpl _$$RandomLevelImplFromJson(Map<String, dynamic> json) =>
-    _$RandomLevelImpl(
-      id: json['id'] as String,
-      name: json['name'] as String,
-      difficulty: $enumDecode(_$DifficultyEnumMap, json['difficulty']),
-      type: $enumDecodeNullable(_$LevelTypeEnumMap, json['type']) ??
-          LevelType.position,
-      range: const PairConverter().fromJson(json['range'] as String),
-      secondsDuration: (json['secondsDuration'] as num).toDouble(),
-      expressions: (json['expressions'] as List<dynamic>?)
-              ?.map((e) => const ExpressionConverter().fromJson(e as String))
-              .toList() ??
-          const [],
-      $type: json['runtimeType'] as String?,
-    );
-
-Map<String, dynamic> _$$RandomLevelImplToJson(_$RandomLevelImpl instance) =>
-    <String, dynamic>{
-      'id': instance.id,
-      'name': instance.name,
-      'difficulty': _$DifficultyEnumMap[instance.difficulty]!,
-      'type': _$LevelTypeEnumMap[instance.type]!,
-      'range': const PairConverter().toJson(instance.range),
-      'secondsDuration': instance.secondsDuration,
-      'expressions':
-          instance.expressions.map(const ExpressionConverter().toJson).toList(),
-      'runtimeType': instance.$type,
-    };
-
-const _$DifficultyEnumMap = {
-  Difficulty.easy: 'easy',
-  Difficulty.medium: 'medium',
-  Difficulty.hard: 'hard',
 };

--- a/lib/ui/screens/level_selector/level_selector_screen.dart
+++ b/lib/ui/screens/level_selector/level_selector_screen.dart
@@ -8,42 +8,52 @@ import 'package:imitador/model/activity/activity.dart';
 import 'package:imitador/model/enum/difficulty.dart';
 import 'package:imitador/model/enum/play_session_type.dart';
 import 'package:imitador/model/level/level.dart';
+import 'package:imitador/model/user/user.dart';
 import 'package:imitador/ui/router/app_router.dart';
 import 'package:imitador/ui/section/activity/activity_section_cubit.dart';
 import 'package:imitador/ui/section/game_session/game_session_section_cubit.dart';
+import 'package:imitador/ui/section/global/global_section_cubit.dart';
 import 'package:imitador/ui/theme/app_theme.dart';
 import 'package:imitador/ui/theme/level_card.dart';
 
 import 'level_selector_cubit.dart';
 
 final dummyLevels = [
-  Level.random(
+  Level(
     id: '1',
     name: 'Fácil',
     difficulty: Difficulty.easy,
     secondsDuration: 10,
-    range: const Pair(0, 10),
+    minPosition: 0,
+    maxPosition: 10,
+    expressions: [],
   ),
-  Level.random(
+  Level(
     id: '2',
     name: 'Medio',
     difficulty: Difficulty.medium,
     secondsDuration: 10,
-    range: const Pair(0, 10),
+    minPosition: 0,
+    maxPosition: 10,
+    expressions: [],
   ),
-  Level.random(
+  Level(
     id: '3',
     name: 'Difícil',
     difficulty: Difficulty.hard,
     secondsDuration: 10,
-    range: const Pair(0, 10),
+    minPosition: 0,
+    maxPosition: 10,
+    expressions: [],
   ),
-  Level.fixed(
+  Level(
     id: '4',
     name: "Se mueve se mueve",
+    difficulty: null,
     expressions: [],
     secondsDuration: 10,
-    range: const Pair(0, 10),
+    minPosition: 0,
+    maxPosition: 10,
   ),
 ];
 
@@ -52,10 +62,11 @@ class LevelSelectorScreen extends StatelessWidget {
   const LevelSelectorScreen({super.key});
 
   @override
-  Widget build(BuildContext context) => BlocProvider(
-        create: (_) => LevelSelectorCubit(),
-        child: _LevelSelectorContentScreen(
-          levels: dummyLevels,
+  Widget build(BuildContext context) =>
+      BlocBuilder<GlobalSectionCubit, GlobalSectionState>(
+        builder: (context, state) => _LevelSelectorContentScreen(
+          levels: state.levels ?? [],
+          user: state.user,
         ),
       );
 }
@@ -71,16 +82,20 @@ class SessionLevelSelectorScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => switch (sessionType) {
-        PlaySessionType.gameSession => BlocBuilder<ActivitySectionCubit, ActivitySectionState>(
-          builder: (context, state) => _LevelSelectorContentScreen(
-            levels: state.activity.levels,
+        PlaySessionType.gameSession =>
+          BlocBuilder<ActivitySectionCubit, ActivitySectionState>(
+            builder: (context, state) => _LevelSelectorContentScreen(
+              levels: state.activity.levels,
+              user: state.user,
+            ),
           ),
-        ),
-        PlaySessionType.activity => BlocBuilder<GameSessionSectionCubit, GameSessionSectionState>(
-          builder: (context, state) => _LevelSelectorContentScreen(
-            levels: state.session.activity.levels,
+        PlaySessionType.activity =>
+          BlocBuilder<GameSessionSectionCubit, GameSessionSectionState>(
+            builder: (context, state) => _LevelSelectorContentScreen(
+              levels: state.session.activity.levels,
+              user: state.user,
+            ),
           ),
-        ),
         PlaySessionType.level => Container(), // We shouldn't arrive here
       };
 }
@@ -88,9 +103,11 @@ class SessionLevelSelectorScreen extends StatelessWidget {
 class _LevelSelectorContentScreen extends StatelessWidget {
   final List<Level> levels;
   final List<Activity> activities;
+  final User? user;
 
   const _LevelSelectorContentScreen({
     required this.levels,
+    required this.user,
     this.activities = const [],
     super.key,
   });
@@ -120,8 +137,8 @@ class _LevelSelectorContentScreen extends StatelessWidget {
                         textAlign: TextAlign.center,
                       ),
                       _LevelsRow(
-                          levels: dummyLevels
-                              .filter((it) => it is RandomLevel)
+                          levels: levels
+                              .filter((it) => it.difficulty != null)
                               .toList()),
                     ],
                   ),
@@ -139,8 +156,8 @@ class _LevelSelectorContentScreen extends StatelessWidget {
                         textAlign: TextAlign.center,
                       ),
                       _LevelsRow(
-                          levels: dummyLevels
-                              .filter((it) => it is FixedLevel)
+                          levels: levels
+                              .filter((it) => it.difficulty == null)
                               .toList()),
                     ],
                   ),
@@ -160,7 +177,7 @@ class _LevelSelectorContentScreen extends StatelessWidget {
                     spacing: 24.w,
                     children: [
                       Text(
-                        "¡Hola, invitado!",
+                        "¡Hola, ${user?.name ?? "invitado"}!",
                         style: context.theme.textStyles.titleLarge!.copyWith(),
                       ),
                       ElevatedButton(

--- a/lib/ui/section/global/global_section_cubit.dart
+++ b/lib/ui/section/global/global_section_cubit.dart
@@ -2,8 +2,11 @@ import 'dart:async';
 
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:imitador/core/common/logger.dart';
 import 'package:imitador/core/di/di_provider.dart';
+import 'package:imitador/core/repository/level_repository.dart';
 import 'package:imitador/core/repository/session_repository.dart';
+import 'package:imitador/model/level/level.dart';
 import 'package:imitador/model/user/user.dart';
 
 part 'global_section_state.dart';
@@ -12,22 +15,31 @@ part 'global_section_cubit.freezed.dart';
 
 class GlobalSectionCubit extends Cubit<GlobalSectionState> {
   final SessionRepository _sessionRepository = DiProvider.get();
+  final LevelRepository _levelRepository = DiProvider.get();
 
   late StreamSubscription<User?> _userSubscription;
+  late StreamSubscription<List<Level>?> _levelsSubscription;
 
   GlobalSectionCubit() : super(const GlobalSectionState.state()) {
     _initStreams();
   }
 
-  void _initStreams() {
+  void _initStreams() async {
     _userSubscription = _sessionRepository.getUserInfo().listen((user) {
       emit(state.copyWith(user: user));
     });
+    // _levelsSubscription = _levelRepository.getLevels().listen((levels) {
+    //   emit(state.copyWith(levels: levels));
+    //   Logger.d('GlobalSectionCubit._initStreams: levels: $levels');
+    // });
+    final levels = await _levelRepository.getDirectLevels();
+    emit(state.copyWith(levels: levels));
   }
 
   @override
   Future<void> close() {
     _userSubscription.cancel();
+    _levelsSubscription.cancel();
     return super.close();
   }
 }

--- a/lib/ui/section/global/global_section_cubit.freezed.dart
+++ b/lib/ui/section/global/global_section_cubit.freezed.dart
@@ -17,19 +17,20 @@ final _privateConstructorUsedError = UnsupportedError(
 /// @nodoc
 mixin _$GlobalSectionState {
   User? get user => throw _privateConstructorUsedError;
+  List<Level>? get levels => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(User? user) state,
+    required TResult Function(User? user, List<Level>? levels) state,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(User? user)? state,
+    TResult? Function(User? user, List<Level>? levels)? state,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(User? user)? state,
+    TResult Function(User? user, List<Level>? levels)? state,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -61,7 +62,7 @@ abstract class $GlobalSectionStateCopyWith<$Res> {
           GlobalSectionState value, $Res Function(GlobalSectionState) then) =
       _$GlobalSectionStateCopyWithImpl<$Res, GlobalSectionState>;
   @useResult
-  $Res call({User? user});
+  $Res call({User? user, List<Level>? levels});
 
   $UserCopyWith<$Res>? get user;
 }
@@ -80,12 +81,17 @@ class _$GlobalSectionStateCopyWithImpl<$Res, $Val extends GlobalSectionState>
   @override
   $Res call({
     Object? user = freezed,
+    Object? levels = freezed,
   }) {
     return _then(_value.copyWith(
       user: freezed == user
           ? _value.user
           : user // ignore: cast_nullable_to_non_nullable
               as User?,
+      levels: freezed == levels
+          ? _value.levels
+          : levels // ignore: cast_nullable_to_non_nullable
+              as List<Level>?,
     ) as $Val);
   }
 
@@ -111,7 +117,7 @@ abstract class _$$GlobalSectionStateStateImplCopyWith<$Res>
       __$$GlobalSectionStateStateImplCopyWithImpl<$Res>;
   @override
   @useResult
-  $Res call({User? user});
+  $Res call({User? user, List<Level>? levels});
 
   @override
   $UserCopyWith<$Res>? get user;
@@ -131,12 +137,17 @@ class __$$GlobalSectionStateStateImplCopyWithImpl<$Res>
   @override
   $Res call({
     Object? user = freezed,
+    Object? levels = freezed,
   }) {
     return _then(_$GlobalSectionStateStateImpl(
       user: freezed == user
           ? _value.user
           : user // ignore: cast_nullable_to_non_nullable
               as User?,
+      levels: freezed == levels
+          ? _value._levels
+          : levels // ignore: cast_nullable_to_non_nullable
+              as List<Level>?,
     ));
   }
 }
@@ -144,15 +155,27 @@ class __$$GlobalSectionStateStateImplCopyWithImpl<$Res>
 /// @nodoc
 
 class _$GlobalSectionStateStateImpl implements _GlobalSectionStateState {
-  const _$GlobalSectionStateStateImpl({this.user = null});
+  const _$GlobalSectionStateStateImpl(
+      {this.user = null, final List<Level>? levels = null})
+      : _levels = levels;
 
   @override
   @JsonKey()
   final User? user;
+  final List<Level>? _levels;
+  @override
+  @JsonKey()
+  List<Level>? get levels {
+    final value = _levels;
+    if (value == null) return null;
+    if (_levels is EqualUnmodifiableListView) return _levels;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
 
   @override
   String toString() {
-    return 'GlobalSectionState.state(user: $user)';
+    return 'GlobalSectionState.state(user: $user, levels: $levels)';
   }
 
   @override
@@ -160,11 +183,13 @@ class _$GlobalSectionStateStateImpl implements _GlobalSectionStateState {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$GlobalSectionStateStateImpl &&
-            (identical(other.user, user) || other.user == user));
+            (identical(other.user, user) || other.user == user) &&
+            const DeepCollectionEquality().equals(other._levels, _levels));
   }
 
   @override
-  int get hashCode => Object.hash(runtimeType, user);
+  int get hashCode => Object.hash(
+      runtimeType, user, const DeepCollectionEquality().hash(_levels));
 
   @JsonKey(ignore: true)
   @override
@@ -176,27 +201,27 @@ class _$GlobalSectionStateStateImpl implements _GlobalSectionStateState {
   @override
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
-    required TResult Function(User? user) state,
+    required TResult Function(User? user, List<Level>? levels) state,
   }) {
-    return state(user);
+    return state(user, levels);
   }
 
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function(User? user)? state,
+    TResult? Function(User? user, List<Level>? levels)? state,
   }) {
-    return state?.call(user);
+    return state?.call(user, levels);
   }
 
   @override
   @optionalTypeArgs
   TResult maybeWhen<TResult extends Object?>({
-    TResult Function(User? user)? state,
+    TResult Function(User? user, List<Level>? levels)? state,
     required TResult orElse(),
   }) {
     if (state != null) {
-      return state(user);
+      return state(user, levels);
     }
     return orElse();
   }
@@ -231,11 +256,14 @@ class _$GlobalSectionStateStateImpl implements _GlobalSectionStateState {
 }
 
 abstract class _GlobalSectionStateState implements GlobalSectionState {
-  const factory _GlobalSectionStateState({final User? user}) =
-      _$GlobalSectionStateStateImpl;
+  const factory _GlobalSectionStateState(
+      {final User? user,
+      final List<Level>? levels}) = _$GlobalSectionStateStateImpl;
 
   @override
   User? get user;
+  @override
+  List<Level>? get levels;
   @override
   @JsonKey(ignore: true)
   _$$GlobalSectionStateStateImplCopyWith<_$GlobalSectionStateStateImpl>

--- a/lib/ui/section/global/global_section_state.dart
+++ b/lib/ui/section/global/global_section_state.dart
@@ -4,5 +4,6 @@ part of 'global_section_cubit.dart';
 class GlobalSectionState with _$GlobalSectionState {
   const factory GlobalSectionState.state({
     @Default(null) User? user,
+    @Default(null) List<Level>? levels,
   }) = _GlobalSectionStateState;
 }

--- a/lib/ui/section/level/level_section_cubit.dart
+++ b/lib/ui/section/level/level_section_cubit.dart
@@ -26,9 +26,9 @@ class LevelSectionCubit extends Cubit<LevelSectionState> {
           level: level.copyWith(
             expressions: level.expressions.isNotEmpty ? level.expressions :
                 generateByDifficulty(
-                  range: level.range,
+                  range: Pair(level.minPosition, level.maxPosition),
                   secondsDuration: level.secondsDuration,
-                  difficulty: (level as RandomLevel).difficulty,
+                  difficulty: level.difficulty!,
                 ),
           ),
         )) {


### PR DESCRIPTION
This pull request includes significant updates to the repository and source management, as well as modifications to the `Level` model and UI components to enhance functionality and data handling.

### Repository and Source Management:

* Added new repositories and sources for `Activity` and `Level` in `lib/core/di/di_repository_module.dart` and registered them as lazy singletons. [[1]](diffhunk://#diff-53a70e5faf36a29e05fcb3bcb2369f155b0b6c3cff5e276c3f75e7fa630fe6e9R1-R12) [[2]](diffhunk://#diff-53a70e5faf36a29e05fcb3bcb2369f155b0b6c3cff5e276c3f75e7fa630fe6e9R37-R47)
* Implemented `ActivityRepository` and `LevelRepository` with methods to fetch and manage data from local and remote sources. [[1]](diffhunk://#diff-b81c5db1670fcbbf334c2169087e911e549b01b55853a460f8332451694f2e01R1-R35) [[2]](diffhunk://#diff-52c540f87833a62500c36a2d7718060bb5027bdb3f5a7328103f0c0cb5308c5eR1-R34)

### Model Updates:

* Modified the `Difficulty` enum to use `JsonValue` annotations for better serialization.
* Refactored the `Level` model to combine `fixed` and `random` levels into a single class, updating the JSON serialization logic accordingly. [[1]](diffhunk://#diff-6caef62c3d2792b4ccc30f32a80cfbfbcd4e6f3d125225c2869f181e9460027dL14-R23) [[2]](diffhunk://#diff-9c8db628b5ef5f577584e968ccd803f37c24a640dc5a6ed00c665819beced16fL9-L73)

### UI Enhancements:

* Updated the `LevelSelectorScreen` to fetch levels and user data from the `GlobalSectionCubit` state and display personalized greetings. [[1]](diffhunk://#diff-303bc71b1ab2de038c98fbc5a416e5548b9e194f67159712317c8afa3feeea26R11-R56) [[2]](diffhunk://#diff-303bc71b1ab2de038c98fbc5a416e5548b9e194f67159712317c8afa3feeea26L55-R69) [[3]](diffhunk://#diff-303bc71b1ab2de038c98fbc5a416e5548b9e194f67159712317c8afa3feeea26L74-R96) [[4]](diffhunk://#diff-303bc71b1ab2de038c98fbc5a416e5548b9e194f67159712317c8afa3feeea26R106-R110) [[5]](diffhunk://#diff-303bc71b1ab2de038c98fbc5a416e5548b9e194f67159712317c8afa3feeea26L123-R141) [[6]](diffhunk://#diff-303bc71b1ab2de038c98fbc5a416e5548b9e194f67159712317c8afa3feeea26L142-R160) [[7]](diffhunk://#diff-303bc71b1ab2de038c98fbc5a416e5548b9e194f67159712317c8afa3feeea26L163-R180)

### Additional Source Implementations:

* Added local and remote sources for `Activity` and `Level`, including methods for data fetching and storage. [[1]](diffhunk://#diff-a487befaa0c42d9bac4d1d35444401159b03bf16e60eeb29dbbea95f46693f3cR1-R22) [[2]](diffhunk://#diff-cea699faf0fe036d672b5022df49e161745b12c14aa1edda135849ec8637b9d4R1-R20) [[3]](diffhunk://#diff-c7376458c684ff26c294199824487003f5cf3e481fad58087429ae3a922f7a7bR1-R22) [[4]](diffhunk://#diff-ea8d07fddc06d816e821b3758001093079231639a6f3c7dac9ba01bd933b355dR1-R23)

### Global Section Cubit:

* Integrated `LevelRepository` into `GlobalSectionCubit` to manage level data and updated the initialization logic to fetch levels directly. [[1]](diffhunk://#diff-51307194e0f2b3278e5e3c4131eb7ca39c6ac4c7afac8c50990249201de66a85R5-R9) [[2]](diffhunk://#diff-51307194e0f2b3278e5e3c4131eb7ca39c6ac4c7afac8c50990249201de66a85R18-R42)