### PR TITLE
Added current position indicator to graph

### DIFF
--- a/lib/game/screens/level/game_level_screen.dart
+++ b/lib/game/screens/level/game_level_screen.dart
@@ -76,11 +76,14 @@ class GameLevelPage extends Component
   }
 
   void addPositionValue(Vector2 position) {
-    _graph.addDataPoint(
-      game.level.minPosition + (position.x - game.spriteOutOfBoundsSize) /
-          (game.size.x - Constants.trackingSpriteSize) *
-          (game.level.maxPosition - game.level.minPosition),
-    );
+    _graph.addDataPoint(toScaledPosition(position.x));
+  }
+
+  double toScaledPosition(double position) {
+    return game.level.minPosition +
+        (position - game.spriteOutOfBoundsSize) /
+            (game.size.x - Constants.trackingSpriteSize) *
+            (game.level.maxPosition - game.level.minPosition);
   }
 
   @override
@@ -88,7 +91,7 @@ class GameLevelPage extends Component
     final newX = (event.localPosition.x)
         .clamp(_sparky.size.x / 2, game.size.x - _sparky.size.x / 2);
     _sparky.position = Vector2(newX, _sparky.position.y);
-    _graph.updateCurrentPosition(newX);
+    _graph.updateCurrentPosition(toScaledPosition(newX));
   }
 
   @override


### PR DESCRIPTION
This pull request includes changes to the `class GameLevelPage` in the `lib/game/screens/level/game_level_screen.dart` file to refactor the code for better readability and maintainability. The most important changes include extracting a calculation into a separate method and updating method calls to use this new method.

Code refactoring:

* Extracted the position scaling calculation into a new method `toScaledPosition` to improve code readability and reuse.
* Updated the `addPositionValue` and `onPointerMove` methods to use the newly created `toScaledPosition` method for position scaling.