### PR TITLE
Added free movement level

### DIFF
--- a/lib/ui/screens/level/level_screen.dart
+++ b/lib/ui/screens/level/level_screen.dart
@@ -21,8 +21,12 @@ class LevelScreen extends StatelessWidget {
       BlocBuilder<LevelSectionCubit, LevelSectionState>(
         builder: (context, state) => _LevelContentScreen(
           onFinishedWithResult: (samples) {
-            context.read<LevelSectionCubit>().addAttemptFromSamples(samples);
-            context.router.replace(const LevelResultsRoute());
+            if (state.level.id == "freeMovement") {
+              context.router.maybePop();
+            } else {
+              context.read<LevelSectionCubit>().addAttemptFromSamples(samples);
+              context.router.replace(const LevelResultsRoute());
+            }
           },
           level: state.level,
         ),

--- a/lib/ui/screens/level_selector/level_selector_screen.dart
+++ b/lib/ui/screens/level_selector/level_selector_screen.dart
@@ -65,7 +65,18 @@ class LevelSelectorScreen extends StatelessWidget {
   Widget build(BuildContext context) =>
       BlocBuilder<GlobalSectionCubit, GlobalSectionState>(
         builder: (context, state) => _LevelSelectorContentScreen(
-          levels: state.levels ?? [],
+          levels: [
+            Level(
+              id: "freeMovement",
+              name: "Movimiento Libre (práctica)",
+              difficulty: null,
+              minPosition: 0,
+              maxPosition: 10,
+              secondsDuration: 10,
+              positionExpressions: [],
+            ),
+            ...state.levels ?? [],
+          ],
           user: state.user,
           activities: state.activities ?? [],
         ),

--- a/lib/ui/section/level/level_section_cubit.dart
+++ b/lib/ui/section/level/level_section_cubit.dart
@@ -27,13 +27,13 @@ class LevelSectionCubit extends Cubit<LevelSectionState> {
     required Level level,
   }) : super(LevelSectionState.state(
           level: level.copyWith(
-            positionExpressions: level.positionExpressions.isNotEmpty
+            positionExpressions: level.id != "freeMovement" ? (level.positionExpressions.isNotEmpty
                 ? level.positionExpressions
                 : generateByDifficulty(
                     range: Pair(level.minPosition, level.maxPosition),
                     secondsDuration: level.secondsDuration,
                     difficulty: level.difficulty!,
-                  ).map((it) => it.toString()).toList(),
+                  ).map((it) => it.toString()).toList()) : [],
           ),
         )) {
     _initStreams();


### PR DESCRIPTION
This pull request introduces a new "Free Movement" practice level to the application, along with logic to handle its specific behavior. The changes ensure that this level behaves differently from other levels by bypassing certain game mechanics and simplifying the user flow.

### Addition of the "Free Movement" level:

* [`lib/ui/screens/level_selector/level_selector_screen.dart`](diffhunk://#diff-303bc71b1ab2de038c98fbc5a416e5548b9e194f67159712317c8afa3feeea26L68-R79): Added a new "Free Movement" level to the list of levels displayed in the level selector screen. This level has no difficulty, a fixed duration, and an empty set of position expressions.

### Special handling for the "Free Movement" level:

* [`lib/ui/section/level/level_section_cubit.dart`](diffhunk://#diff-46a6a4cfc70fe43270ce00f9654ff83ec11bb529ed6dad23f119fc18eed4384cL30-R36): Modified the `LevelSectionCubit` to skip generating position expressions for the "Free Movement" level, ensuring it starts with an empty set of expressions.
* [`lib/ui/screens/level/level_screen.dart`](diffhunk://#diff-4934ef0f9e1f78d0ff73ffd9c1b428d6a5c36803d548b2284a1f90bd3af45abdR24-R29): Updated the level completion logic to immediately return to the previous screen for the "Free Movement" level, instead of proceeding to the results screen.