### PR TITLE
Add logout functionality to settings screen

### DIFF
--- a/lib/ui/screens/settings/settings_screen.dart
+++ b/lib/ui/screens/settings/settings_screen.dart
@@ -94,6 +94,26 @@ class _SettingsContentScreen extends StatelessWidget {
                             ),
                           ],
                         ),
+                        if (state.user != null) ...[
+                          const DarkHorizontalDivider(),
+                          Align(
+                            alignment: Alignment.centerRight,
+                            child: SecondaryButton(
+                              label: "Cerrar sesión",
+                              onPressed: () async {
+                                await context
+                                    .read<GlobalSectionCubit>()
+                                    .logOut();
+                                // TODO FIXME: Probable race condition
+                                await Future.delayed(
+                                    const Duration(seconds: 1));
+                                if (context.mounted) {
+                                  context.router.replace(const WelcomeRoute());
+                                }
+                              },
+                            ),
+                          ),
+                        ],
                       ],
                     ),
                   ),

--- a/lib/ui/section/global/global_section_cubit.dart
+++ b/lib/ui/section/global/global_section_cubit.dart
@@ -25,9 +25,10 @@ class GlobalSectionCubit extends Cubit<GlobalSectionState> {
   StreamSubscription<List<Level>?>? _levelsSubscription;
   StreamSubscription<List<Activity>?>? _activitiesSubscription;
 
-  GlobalSectionCubit() : super(GlobalSectionState.state(
-    microbitController: MicrobitController(),
-  )) {
+  GlobalSectionCubit()
+      : super(GlobalSectionState.state(
+          microbitController: MicrobitController(),
+        )) {
     _initStreams();
   }
 
@@ -44,7 +45,8 @@ class GlobalSectionCubit extends Cubit<GlobalSectionState> {
     _activitiesSubscription =
         _activityRepository.getActivities().listen((activities) {
       emit(state.copyWith(activities: activities));
-      Logger.d('GlobalSectionCubit._initStreams: activities: ${activities?.length}');
+      Logger.d(
+          'GlobalSectionCubit._initStreams: activities: ${activities?.length}');
     });
   }
 
@@ -57,7 +59,7 @@ class GlobalSectionCubit extends Cubit<GlobalSectionState> {
     return connected;
   }
 
-  void logOut() async {
+  Future<void> logOut() async {
     await _sessionRepository.logOut();
     _levelRepository.refreshLevels();
     _activityRepository.refresh();


### PR DESCRIPTION
TODO: Fix probable race condition/weird behavior

- Introduced a "Cerrar sesión" button in the settings screen, allowing users to log out.
- Implemented a delay after logout to handle potential race conditions before navigating to the Welcome screen.
- Updated logOut method in GlobalSectionCubit to return a Future for better async handling.
![image](https://github.com/user-attachments/assets/3112400e-9488-48dd-9b45-62fa7738ec3e)
