### PR TITLE
Integrate attempt tracking in level selector screen (student - game session)

### DIFF
--- a/lib/ui/theme/components/cards.dart
+++ b/lib/ui/theme/components/cards.dart
@@ -15,10 +15,12 @@ class LevelCard extends StatelessWidget {
   final String? image;
   final double? customHeight;
   final double? customWidth;
+  final int? stars;
 
   const LevelCard({
     required this.label,
     required this.onPressed,
+    this.stars,
     super.key,
     this.image,
     this.customHeight,
@@ -27,6 +29,10 @@ class LevelCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    Widget? starsWidget;
+    if (stars != null && stars! > 0) {
+      starsWidget = starsImage(stars!.toDouble());
+    }
     return InkWell(
         onTap: onPressed,
         child: SizedBox(
@@ -51,6 +57,7 @@ class LevelCard extends StatelessWidget {
                       style: context.theme.textStyles.headlineSmall,
                     ),
                   ),
+                  if (starsWidget != null) starsWidget,
                 ],
               ),
             ),
@@ -58,6 +65,23 @@ class LevelCard extends StatelessWidget {
         ));
   }
 }
+
+Image starsImage(double stars) => Image.asset(
+      switch (stars) {
+        < 1 => Assets.images.rating05,
+        < 1.5 => Assets.images.rating1,
+        < 2 => Assets.images.rating15,
+        < 2.5 => Assets.images.rating2,
+        < 3 => Assets.images.rating25,
+        < 3.5 => Assets.images.rating3,
+        < 4 => Assets.images.rating35,
+        < 4.5 => Assets.images.rating4,
+        < 5 => Assets.images.rating45,
+        _ => Assets.images.rating5,
+      }
+          .path,
+      height: 48.h,
+    );
 
 class ActivityCard extends StatelessWidget {
   final Activity activity;


### PR DESCRIPTION
This pull request introduces functionality to display user-specific star ratings for levels in the level selector screen. The most important changes involve integrating attempt data into the UI, updating the `LevelCard` component to show star ratings, and modifying relevant classes to support these updates.

### Integration of Attempt Data:
* Added imports for `AttemptRepository`, `DiProvider`, and `Attempt` in `lib/ui/screens/level_selector/level_selector_screen.dart` to fetch and manage attempt data.
* Updated the `SessionLevelSelectorScreen` to use a `StreamBuilder` to fetch and filter attempts based on the current game session ID. The filtered attempts are passed to `_LevelSelectorContentScreen`.

### Updates to `_LevelSelectorContentScreen`:
* Added a new `attempts` parameter to `_LevelSelectorContentScreen` to handle attempt data and updated its constructor with a default empty list. [[1]](diffhunk://#diff-303bc71b1ab2de038c98fbc5a416e5548b9e194f67159712317c8afa3feeea26R146) [[2]](diffhunk://#diff-303bc71b1ab2de038c98fbc5a416e5548b9e194f67159712317c8afa3feeea26R155)
* Passed the `attempts` and `user` parameters to `_LevelCards` for further processing. [[1]](diffhunk://#diff-303bc71b1ab2de038c98fbc5a416e5548b9e194f67159712317c8afa3feeea26R203-R204) [[2]](diffhunk://#diff-303bc71b1ab2de038c98fbc5a416e5548b9e194f67159712317c8afa3feeea26R225-R226)

### Enhancements to `_LevelCards`:
* Introduced `attempts` and `user` parameters to `_LevelCards` and added logic to calculate the highest star rating for each level based on user-specific attempts. This rating is passed to `LevelCard`. [[1]](diffhunk://#diff-303bc71b1ab2de038c98fbc5a416e5548b9e194f67159712317c8afa3feeea26R262-R289) [[2]](diffhunk://#diff-303bc71b1ab2de038c98fbc5a416e5548b9e194f67159712317c8afa3feeea26L273-R311)

### Updates to `LevelCard` Component:
* Added a new `stars` parameter to `LevelCard` and implemented logic to display a star rating widget if the `stars` value is provided. [[1]](diffhunk://#diff-bd5aaefc45dbe2c3af2bc9bbec4fa174480cf759be7205af4313fee1f9a54162R18-R23) [[2]](diffhunk://#diff-bd5aaefc45dbe2c3af2bc9bbec4fa174480cf759be7205af4313fee1f9a54162R32-R35) [[3]](diffhunk://#diff-bd5aaefc45dbe2c3af2bc9bbec4fa174480cf759be7205af4313fee1f9a54162R60)
* Introduced a `starsImage` helper function to map star ratings to corresponding image assets.
![image](https://github.com/user-attachments/assets/e9b38ee7-1cf1-44ef-ad55-d4f125c4f71c)
