### PR TITLE
Use speed expressions when available

### DIFF
--- a/lib/game/screens/level/game_level_screen.dart
+++ b/lib/game/screens/level/game_level_screen.dart
@@ -90,7 +90,9 @@ class GameLevelPage extends Component
           position: Vector2(70.w, 14.h),
           children: [
             _graph = GraphComponent(
-              fixedExpressions: game.level.positionExpressions
+              fixedExpressions: (game.level.type == LevelType.position
+                      ? game.level.positionExpressions
+                      : game.level.speedExpressions)
                   .map((it) => Parser().parse(it))
                   .toList(),
               onFinishedSampling: finishSampling,
@@ -119,8 +121,10 @@ class GameLevelPage extends Component
         position: Vector2(490.w, 82.h),
       ),
       _ruler = RulerComponent(
-        size: Vector2(gameInitialSize.x - (game.spriteOutOfBoundsSize - 10.w), 90.h),
-        position: Vector2((game.spriteOutOfBoundsSize / 2) - 5.w, gameInitialSize.y),
+        size: Vector2(
+            gameInitialSize.x - (game.spriteOutOfBoundsSize - 10.w), 90.h),
+        position:
+            Vector2((game.spriteOutOfBoundsSize / 2) - 5.w, gameInitialSize.y),
         anchor: Anchor.bottomLeft,
         minDistance: game.level.minPosition,
         maxDistance: game.level.maxPosition,
@@ -128,9 +132,9 @@ class GameLevelPage extends Component
       ),
       _paperBall = PaperBall(
         updatePositionCallback: addPositionValue,
-      )..position = Vector2(
-          gameInitialSize.x / 2, gameInitialSize.y - 70.h)
-      ..anchor = Anchor.bottomCenter,
+      )
+        ..position = Vector2(gameInitialSize.x / 2, gameInitialSize.y - 70.h)
+        ..anchor = Anchor.bottomCenter,
     ]);
   }
 


### PR DESCRIPTION
This pull request introduces updates to the `GameLevelPage` component in `lib/game/screens/level/game_level_screen.dart` to enhance flexibility for level-specific configurations and improve code formatting for readability. The most important changes include adding support for dynamic expression types based on the level type and reformatting code for better maintainability.

### Functional Improvements:
* Updated the `_graph` component to dynamically select between `positionExpressions` and `speedExpressions` based on the `LevelType` of the game level. This change allows the game to support different types of levels with distinct expressions.

### Code Formatting:
* Reformatted the initialization of the `_ruler` and `_paperBall` components to improve readability by aligning multi-line expressions and ensuring consistent indentation. These changes do not alter functionality but enhance code clarity.