### PR TITLE
Changed graph axis labels

### DIFF
--- a/lib/game/components/graph/graph_component.dart
+++ b/lib/game/components/graph/graph_component.dart
@@ -100,8 +100,8 @@ class GraphComponent extends PositionComponent
       drawGrid: true,
       gridPaint: gridPaint,
       yAxisLabel: switch (game.level.type) {
-        LevelType.position => "X(t)",
-        LevelType.speed => "V(t)",
+        LevelType.position => "X(m)",
+        LevelType.speed => "V(m/s)",
       },
     );
   }
@@ -328,21 +328,6 @@ void drawGraph({
     axisLinePaint,
   );
 
-  // Dibujar etiquetas
-  drawTextAt(
-    canvas: canvas,
-    text: yAxisLabel,
-    x: yAxisXOffset - 50,
-    y: 15,
-    color: fontColor,
-  );
-  drawTextAt(
-    canvas: canvas,
-    text: "t",
-    x: size.x - 15,
-    y: xAxisYOffset + 10,
-    color: fontColor,
-  );
 
   for (int i = range.first.ceil(); i <= range.second.floor(); i++) {
     if (i != 0) {
@@ -376,6 +361,21 @@ void drawGraph({
     );
   }
 
+  // Dibujar etiquetas
+  drawTextAt(
+    canvas: canvas,
+    text: yAxisLabel,
+    x: yAxisXOffset - 50.w,
+    y: 15.h,
+    color: fontColor,
+  );
+  drawTextAt(
+    canvas: canvas,
+    text: "t(s)",
+    x: size.x - 15.w,
+    y: xAxisYOffset + 10.h,
+    color: fontColor,
+  );
   // Dibujar las expresiones fijas
   fixedExpressions.forEachIndexed((expression, index) {
     final startTime = index * secondsDuration / fixedExpressions.length;

--- a/lib/ui/screens/results/results_screen.dart
+++ b/lib/ui/screens/results/results_screen.dart
@@ -297,7 +297,7 @@ class GraphPainter extends CustomPainter {
       range: range,
       mathContext: mathContext,
       fontColor: Colors.black,
-      yAxisLabel: speed ? "V(t)" : "X(t)",
+      yAxisLabel: speed ? "V(m/s)" : "X(m)",
     );
   }
 


### PR DESCRIPTION
This pull request updates the axis labels in graph components to include units of measurement and adjusts the positioning of the labels for better responsiveness. The changes ensure consistency in label formatting and improve the display across different screen sizes.

### Updates to axis labels:

* [`lib/game/components/graph/graph_component.dart`](diffhunk://#diff-5ca56501315bd19f3715b2129c0d4261c85a0d51f8a8c04b004ff547525a3c9eL103-R104): Updated `yAxisLabel` to include units of measurement, changing "X(t)" to "X(m)" and "V(t)" to "V(m/s)" for better clarity.
* [`lib/ui/screens/results/results_screen.dart`](diffhunk://#diff-7a0aa475e48d1f5bad978eaac33040506659cce485efa436a859e122f1471b06L300-R300): Modified `yAxisLabel` in `GraphPainter` to reflect the same unit updates, ensuring consistency across components.

### Improvements to label positioning:

* [`lib/game/components/graph/graph_component.dart`](diffhunk://#diff-5ca56501315bd19f3715b2129c0d4261c85a0d51f8a8c04b004ff547525a3c9eR364-R378): Adjusted the `drawGraph` method to use responsive positioning for axis labels by replacing fixed offsets with `.w` and `.h` extensions. Additionally, updated the x-axis label to "t(s)" to include the unit of time.