### PR TITLE
Added smoothing to microbit samples

### DIFF
--- a/lib/core/common/helper/transformer_helper.dart
+++ b/lib/core/common/helper/transformer_helper.dart
@@ -62,3 +62,18 @@ List<Pair<double, double>> integrateSamples(
 
   return integratedSamples;
 }
+
+extension SampleExtensions on List<Pair<double, double>> {
+  List<Pair<double, double>> rollingAverage(int windowSize) {
+    final List<Pair<double, double>> averagedSamples = [];
+
+    for (int i = 0; i < length - windowSize - 1; i++) {
+      final window = slice(i, i + windowSize);
+      final time = window.first.first;
+      final averageValue = window.map((e) => e.second).average();
+      averagedSamples.add(Pair(time, averageValue));
+    }
+
+    return averagedSamples;
+  }
+}

--- a/lib/game/components/graph/graph_component.dart
+++ b/lib/game/components/graph/graph_component.dart
@@ -25,6 +25,7 @@ class GraphComponent extends PositionComponent
   final VoidCallback? onFinishedSampling;
   final Pair<double, double> distanceRange;
   final List<Pair<double, double>> distances = [];
+  List<Pair<double, double>> averageDistances = [];
   List<Pair<double, double>> speeds = [];
   double currentTime = 0;
   double currentPosition = 0;
@@ -40,9 +41,11 @@ class GraphComponent extends PositionComponent
   final mathContext = ContextModel();
   late double xAxisYOffset;
   late final double effectiveTimeSize;
+  bool averageSamples;
 
   GraphComponent({
     required this.fixedExpressions,
+    required this.averageSamples,
     this.secondsDuration = 10,
     this.distanceRange = const Pair(0, 10),
     this.onFinishedSampling,
@@ -61,6 +64,9 @@ class GraphComponent extends PositionComponent
   void addDataPoint(double distance) {
     if (sampling) {
       distances.add(Pair(currentTime, distance));
+      if (averageSamples) {
+        averageDistances = distances.rollingAverage(10);
+      }
       if (game.level.type == LevelType.speed) {
         speeds = deriveSamples(distances, 10);
       }
@@ -85,7 +91,9 @@ class GraphComponent extends PositionComponent
       axisLinePaint: axisLinePaint,
       pointPaint: pointPaint,
       yAxisXOffset: game.spriteOutOfBoundsSize,
-      samples: game.level.type == LevelType.position ? distances : speeds,
+      samples: game.level.type == LevelType.position
+          ? (averageSamples ? averageDistances : distances)
+          : speeds,
       secondsDuration: secondsDuration.toDouble(),
       currentValue: currentPosition,
       sampling: sampling,

--- a/lib/game/screens/level/game_level_screen.dart
+++ b/lib/game/screens/level/game_level_screen.dart
@@ -53,6 +53,7 @@ class GameLevelPage extends Component
     if (usingMicrobit) {
       _microbitSubscription =
           state.microbitController.dataStream.listen(onMicrobitData);
+      _graph.averageSamples = true;
     } else {
       _microbitSubscription?.cancel();
       _microbitSubscription = null;
@@ -97,6 +98,7 @@ class GameLevelPage extends Component
               secondsDuration: game.level.secondsDuration.toInt(),
               distanceRange:
                   Pair(game.level.minPosition, game.level.maxPosition),
+              averageSamples: usingMicrobit,
             )
               ..size = Vector2(notebookWidth - 80.w, 600.h)
               ..position = Vector2(10.w, 70.h)


### PR DESCRIPTION
This pull request introduces functionality for calculating and displaying rolling averages of data samples in the graph component. The most notable changes include the addition of a `rollingAverage` extension method, updates to the `GraphComponent` class to support rolling averages, and integration with the game level screen to enable this feature when using a micro:bit.

### Enhancements to data processing:

* Added a `rollingAverage` extension method to the `List<Pair<double, double>>` type in `transformer_helper.dart` for calculating rolling averages over a specified window size.

### Updates to `GraphComponent`:

* Introduced a new `averageSamples` boolean property and an `averageDistances` list to manage and store rolling averages. [[1]](diffhunk://#diff-5ca56501315bd19f3715b2129c0d4261c85a0d51f8a8c04b004ff547525a3c9eR28) [[2]](diffhunk://#diff-5ca56501315bd19f3715b2129c0d4261c85a0d51f8a8c04b004ff547525a3c9eR44-R48)
* Updated the `addDataPoint` method to compute rolling averages when `averageSamples` is enabled.
* Modified the graph rendering logic to use `averageDistances` instead of raw `distances` when `averageSamples` is active.

### Integration with game level screen:

* Enabled the `averageSamples` feature in `GameLevelPage` when a micro:bit is in use, ensuring smoother data visualization. [[1]](diffhunk://#diff-2732a42cb807149b195384810d24db99f31dbd58abe0815c8d95343116e2172dR56) [[2]](diffhunk://#diff-2732a42cb807149b195384810d24db99f31dbd58abe0815c8d95343116e2172dR101)